### PR TITLE
Proposed change to explanation behaviour

### DIFF
--- a/src/algorithms/controllers/unionFindUnion.js
+++ b/src/algorithms/controllers/unionFindUnion.js
@@ -27,7 +27,7 @@ export const N_GRAPH = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10'];
 
 let isRankVisible = false;
 export function unionFindChunkerRefresh(algorithm) {
-  if (!algorithm) return;
+  if (!algorithm || algorithm.name.id != 'unionFind') return;
   let vis = algorithm.chunker.visualisers;
   let isVisible =
     algorithm.collapse.unionFind.union.Maybe_swap ||
@@ -324,13 +324,13 @@ export default {
 
       chunker.add(
         'rank[m] <- rank[m] + 1',
-        (vis, root1, root2) => {
-          vis.array.updateValueAt(RANK_IDX, root2, rankArr[root2]);
-          vis.array.updateValueAt(RANK_IDX, root1, rankArr[root1]);
+        (vis, root1, root2, updatedRank1, updatedRank2) => {
+          vis.array.updateValueAt(RANK_IDX, root2, updatedRank2);
+          vis.array.updateValueAt(RANK_IDX, root1, updatedRank1);
           this.unhighlight(vis.array, RANK_IDX, root1);
           this.highlight(vis.array, RANK_IDX, root2, ARRAY_COLOUR_CODES.GREEN);
         },
-        [root1, root2]
+        [root1, root2, rankArr[root1], rankArr[root2]]
       );
     }
   },

--- a/src/algorithms/controllers/unionFindUnion.js
+++ b/src/algorithms/controllers/unionFindUnion.js
@@ -102,9 +102,9 @@ export default {
   /**
    * Highlight the current node.
    * @param {*} visObj
-   * @param {*} index1 
-   * @param {*} index2 
-   * @param {*} colour 
+   * @param {*} index1
+   * @param {*} index2
+   * @param {*} colour
    */
   highlight(visObj, index1, index2, colour) {
     if (visObj.key === 'array') {

--- a/src/components/right-panel/LineNumHighLight.js
+++ b/src/components/right-panel/LineNumHighLight.js
@@ -144,7 +144,7 @@ function pseudocodeBlock(algorithm, dispatch, blockName, lineNum) {
     if (algorithm.collapse[algorithm.id.name][algorithm.id.mode][blockName] && line.lineExplanButton !== undefined) {
       lineExplanButton =
         <button
-          id={"buttonexpl"+i}
+          id={"buttonexpl" + i}
           className={line.explanation === algorithm.lineExplanation ? 'line-explanation-button-active' : 'line-explanation-button-negative'}
           onClick={() => { dispatch(GlobalActions.LineExplan, line.explanation); }}
         >
@@ -154,11 +154,11 @@ function pseudocodeBlock(algorithm, dispatch, blockName, lineNum) {
     if (line.ref) {
       codeLines.push(
         <p
-          key={i}
-          className={(!algorithm.collapse[algorithm.id.name][algorithm.id.mode][line.ref]
-            && blockContainsBookmark(algorithm, line.ref)) ? 'active' : ''}
-          role="presentation"
-          onClick={() => { dispatch(GlobalActions.LineExplan, line.explanation); }}
+        // key={i}
+        //className={(!algorithm.collapse[algorithm.id.name][algorithm.id.mode][line.ref]
+        //  && blockContainsBookmark(algorithm, line.ref)) ? 'active' : ''}
+        //  role="presentation"
+        //  onClick={() => { dispatch(GlobalActions.LineExplan, line.explanation); }}
         >
           <span>{i}</span>
           <span>
@@ -183,7 +183,7 @@ function pseudocodeBlock(algorithm, dispatch, blockName, lineNum) {
           </span>
           <span
             id={(line.bookmark !== undefined && algorithm.bookmark === line.bookmark) ? 'activebtn' : ''}>
-              {lineExplanButton}</span>
+            {lineExplanButton}</span>
           {pseudoceArary}
         </p>,
       );
@@ -198,7 +198,7 @@ function pseudocodeBlock(algorithm, dispatch, blockName, lineNum) {
           key={i}
           className={(line.bookmark !== undefined && algorithm.bookmark === line.bookmark) ? 'active' : ''}
           role="presentation"
-          onClick={() => { dispatch(GlobalActions.LineExplan, line.explanation); }}
+        //onClick={() => { dispatch(GlobalActions.LineExplan, line.explanation); }}
         >
           <span>{i}</span>
           <span>{null}</span>
@@ -249,7 +249,7 @@ const LineNumHighLight = ({ fontSize, fontSizeIncrement }) => {
         {cl}
         {pseudoCodePad}
       </div>
-      { algorithm.lineExplanation ? (
+      {algorithm.lineExplanation ? (
         <LineExplanation
           explanation={algorithm.lineExplanation}
           fontSize={fontSize}

--- a/src/context/actions.js
+++ b/src/context/actions.js
@@ -165,7 +165,8 @@ export const GlobalActions = {
     const chunker = new Chunker(() => controller[params.mode].initVisualisers(params));
     controller[params.mode].run(chunker, params);
     const bookmarkInfo = chunker.next();
-    const firstLineExplan = findBookmark(procedurePseudocode, bookmarkInfo.bookmark).explanation;
+    //const firstLineExplan = findBookmark(procedurePseudocode, bookmarkInfo.bookmark).explanation;
+    const firstLineExplan = null;
     previousState = [];
 
     return {
@@ -191,19 +192,19 @@ export const GlobalActions = {
     let result;
 
     let triggerPauseInCollapse = false;
-    if(typeof playing === 'object'){
+    if (typeof playing === 'object') {
       triggerPauseInCollapse = playing.triggerPauseInCollapse;
       playing = playing.playing;
     }
 
     do {
       result = state.chunker.next(triggerPauseInCollapse);
-      if(!triggerPauseInCollapse){
+      if (!triggerPauseInCollapse) {
         result.pauseInCollapse = false;
       }
     } while (
       !result.pauseInCollapse &&
-      !result.finished && 
+      !result.finished &&
       !isBookmarkVisible(state.pseudocode, state.collapse[state.id.name][state.id.mode], result.bookmark)
     );
     if (result.finished) {


### PR DESCRIPTION
Old behaviour:
- When you click on the line, the explanation pops up regardless of whether the button itself was clicked.
- Similarly, if clicked on toggle the explanation popped up (quite annoying).
- When the algorithm was first loaded, the first explanation popped up.

New behaviour:
- Must click on the explanation button for the explanation to pop up.